### PR TITLE
Fix memory leaks

### DIFF
--- a/gp-aai/src/Main.cpp
+++ b/gp-aai/src/Main.cpp
@@ -202,5 +202,6 @@ int main(int argc, char* argv[])  {
     display_thread.join();
     running = false;
     logic_thread.join();
+    delete world;
     return 0;
 }

--- a/gp-aai/src/game/World.cpp
+++ b/gp-aai/src/game/World.cpp
@@ -209,6 +209,10 @@ continue_to_next:;
     return result_return;
 }
 
+World::~World() {
+    delete this->graph;
+}
+
 TTF_Font** World::getFont() {
     return &this->font;
 }

--- a/gp-aai/src/game/World.h
+++ b/gp-aai/src/game/World.h
@@ -31,6 +31,7 @@ class World {
 
     public:
         World(int w, int h);
+        ~World();
         void update(float delta);
         void render(SDL_Renderer* renderer);
         void event(WorldEvent e, Vector2D pos);

--- a/gp-aai/src/tests/AstarTests.hpp
+++ b/gp-aai/src/tests/AstarTests.hpp
@@ -55,4 +55,5 @@ void run_Astar_tests() {
         cout << "Vertex with position " << vertex->getPosition() << endl;
     }
 
+    delete graph;
 }


### PR DESCRIPTION
In valgrind goes from:
==57583==    definitely lost: 21,032 bytes in 291 blocks
==57583==    indirectly lost: 268,404 bytes in 3,462 blocks

to:
==61962==    definitely lost: 61,832 bytes in 482 blocks
==61962==    indirectly lost: 22,079 bytes in 132 blocks